### PR TITLE
Load test git repo via submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,10 @@ jobs:
       S3_IMAGE_ENDPOINT_CDN: http://s3:9000/image/
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Launch Services
         run: docker-compose up -d
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
       S3_IMAGE_ENDPOINT_CDN: http://s3:9000/image/
 
     steps:
-      - name: Checkout repository and submodules
+      - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
+      - name: Checkout submodules
+        run: git submodule update --init --recursive --remote
       - name: Launch Services
         run: docker-compose up -d
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
-	path = packages/slicknode/test/commands/init/fixtures/project-repo
-	url = https://github.com/slicknode/starter-nextjs-blog.git
+#[submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
+#	path = packages/slicknode/test/commands/init/fixtures/project-repo
+#	url = https://github.com/slicknode/slicknode-project-template-ci.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-#[submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
-#	path = packages/slicknode/test/commands/init/fixtures/project-repo
-#	url = https://github.com/slicknode/slicknode-project-template-ci.git
 [submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
 	path = packages/slicknode/test/commands/init/fixtures/project-repo
 	url = https://github.com/slicknode/slicknode-project-template-ci.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 #[submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
 #	path = packages/slicknode/test/commands/init/fixtures/project-repo
 #	url = https://github.com/slicknode/slicknode-project-template-ci.git
+[submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
+	path = packages/slicknode/test/commands/init/fixtures/project-repo
+	url = https://github.com/slicknode/slicknode-project-template-ci.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/slicknode/test/commands/init/fixtures/project-repo"]
+	path = packages/slicknode/test/commands/init/fixtures/project-repo
+	url = https://github.com/slicknode/starter-nextjs-blog.git

--- a/packages/slicknode/src/commands/init.ts
+++ b/packages/slicknode/src/commands/init.ts
@@ -180,7 +180,7 @@ export default class InitCommand extends BaseCommand {
         // Install node modules if we have package.json
         if (await pathExists(path.join(targetDir, 'package.json'))) {
           cli.action.start('Installing node dependencies');
-          const npmInstallResult = execSync('npm install', {
+          const npmInstallResult = execSync('npm install --prefer-online', {
             cwd: targetDir,
             encoding: 'utf8',
             stdio: 'inherit',

--- a/packages/slicknode/test/commands/init/init.test.ts
+++ b/packages/slicknode/test/commands/init/init.test.ts
@@ -331,7 +331,7 @@ describe('init', () => {
     .workspaceCommand(EMPTY_DIR, [
       'init',
       'test-dir',
-      `${REPO_PATH}#b3262fc1ac2793e7199ba8b2b546d767c45ad4e2`,
+      `${REPO_PATH}#ce1827449ab1d9508616e902645291a348f9a128`,
     ])
     .it('initializes from commit hash successfully', (ctx) => {
       // Check slicknode.yml content
@@ -342,8 +342,11 @@ describe('init', () => {
       );
       expect(slicknodeYml).to.deep.equal({
         dependencies: {
+          '@private/blog': './modules/blog',
           auth: 'latest',
+          content: 'latest',
           core: 'latest',
+          image: 'latest',
           relay: 'latest',
         },
       });

--- a/packages/slicknode/test/commands/init/init.test.ts
+++ b/packages/slicknode/test/commands/init/init.test.ts
@@ -293,12 +293,12 @@ describe('init', () => {
           .toString()
       );
       expect(blogSchema.kind).to.equal(Kind.DOCUMENT);
-      expect(blogSchema.definitions.length).to.be.above(1);
+      expect(blogSchema.definitions.length).to.equal(1);
 
       const postType: DefinitionNode = blogSchema
         .definitions[0] as ObjectTypeDefinitionNode;
       expect(postType.kind).to.equal(Kind.OBJECT_TYPE_DEFINITION);
-      expect(postType.name.value).to.equal('Blog_Post');
+      expect(postType.name.value).to.equal('Blog_Page');
 
       // Check if node_modules was installed
       const nextPackageJson = JSON.parse(
@@ -308,13 +308,13 @@ describe('init', () => {
               ctx.workspace!,
               'test-dir',
               'node_modules',
-              'next',
+              'graphql',
               'package.json'
             )
           )
           .toString()
       );
-      expect(nextPackageJson.name).to.equal('next');
+      expect(nextPackageJson.name).to.equal('graphql');
     });
 
   mockRegistry(test)
@@ -331,7 +331,7 @@ describe('init', () => {
     .workspaceCommand(EMPTY_DIR, [
       'init',
       'test-dir',
-      `${REPO_PATH}#ce1827449ab1d9508616e902645291a348f9a128`,
+      `${REPO_PATH}#94ded0d013ba309a90023ad48503c038f68918dd`,
     ])
     .it('initializes from commit hash successfully', (ctx) => {
       // Check slicknode.yml content
@@ -344,9 +344,7 @@ describe('init', () => {
         dependencies: {
           '@private/blog': './modules/blog',
           auth: 'latest',
-          content: 'latest',
           core: 'latest',
-          image: 'latest',
           relay: 'latest',
         },
       });
@@ -399,9 +397,7 @@ describe('init', () => {
           .toString()
       );
       expect(packageJson.dependencies).to.deep.equal({
-        next: '^9.5.3',
-        react: '^16.13.1',
-        'react-dom': '^16.13.1',
+        graphql: '^16.0.1',
       });
     });
 });

--- a/packages/slicknode/test/commands/init/init.test.ts
+++ b/packages/slicknode/test/commands/init/init.test.ts
@@ -3,9 +3,7 @@ import * as path from 'path';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import { DefinitionNode, Kind, ObjectTypeDefinitionNode, parse } from 'graphql';
-import nock = require('nock');
 import { GET_REPOSITORY_URL_QUERY } from '../../../src/utils/pullDependencies';
-import os from 'os';
 
 const REGISTRY_URL = 'http://localhost/repository/';
 const registryUrlResult = {
@@ -14,6 +12,7 @@ const registryUrlResult = {
 
 describe('init', () => {
   const EMPTY_DIR = path.join(__dirname, 'testprojects', 'empty');
+  const REPO_PATH = path.join(__dirname, 'fixtures', 'project-repo');
 
   test
     .stdout()
@@ -208,211 +207,200 @@ describe('init', () => {
     .catch(/Error checking out git reference "invalidreference"/)
     .it('fails for invalid git reference', (ctx) => {});
 
-  // @TODO: Figure out why this fails on windows and make it pass
-  if (process.platform !== 'win32') {
-    mockRegistry(test)
-      .stdout()
-      .stderr()
-      .cliActions([
-        'Loading project template "https://github.com/slicknode/starter-nextjs-blog.git"',
-        'Installing node dependencies',
-        'Updating dependencies',
-      ])
-      .login()
-      .api(GET_REPOSITORY_URL_QUERY, registryUrlResult)
-      .timeout(180000)
-      .workspaceCommand(EMPTY_DIR, [
-        'init',
-        'test-dir',
-        'https://github.com/slicknode/starter-nextjs-blog.git',
-      ])
-      .it('initializes project successfully from template URL', (ctx) => {
-        // Check slicknode.yml content
-        const slicknodeYml = yaml.safeLoad(
-          fs
-            .readFileSync(
-              path.join(ctx.workspace!, 'test-dir', 'slicknode.yml')
-            )
-            .toString()
-        );
-        expect(slicknodeYml).to.deep.equal({
-          dependencies: {
-            '@private/blog': './modules/blog',
-            auth: 'latest',
-            content: 'latest',
-            core: 'latest',
-            image: 'latest',
-            relay: 'latest',
-          },
-        });
-
-        // Check if core modules were added to cache
-        const coreModuleYml = yaml.safeLoad(
-          fs
-            .readFileSync(
-              path.join(
-                ctx.workspace!,
-                'test-dir',
-                '.slicknode',
-                'cache',
-                'modules',
-                'core',
-                'slicknode.yml'
-              )
-            )
-            .toString()
-        );
-        expect(coreModuleYml).to.deep.equal({
-          module: { id: 'core', label: 'Core' },
-        });
-
-        // Check schema.graphql of core module
-        const coreSchema = parse(
-          fs
-            .readFileSync(
-              path.join(
-                ctx.workspace!,
-                'test-dir',
-                '.slicknode',
-                'cache',
-                'modules',
-                'core',
-                'schema.graphql'
-              )
-            )
-            .toString()
-        );
-        expect(coreSchema.kind).to.equal(Kind.DOCUMENT);
-        expect(coreSchema.definitions.length).to.be.above(5);
-
-        expect(ctx.stdout).to.contain('Project initialized');
-
-        // Check if blog module was downloaded from git
-        const blogSchema = parse(
-          fs
-            .readFileSync(
-              path.join(
-                ctx.workspace!,
-                'test-dir',
-                'modules',
-                'blog',
-                'schema.graphql'
-              )
-            )
-            .toString()
-        );
-        expect(blogSchema.kind).to.equal(Kind.DOCUMENT);
-        expect(blogSchema.definitions.length).to.be.above(1);
-
-        const postType: DefinitionNode = blogSchema
-          .definitions[0] as ObjectTypeDefinitionNode;
-        expect(postType.kind).to.equal(Kind.OBJECT_TYPE_DEFINITION);
-        expect(postType.name.value).to.equal('Blog_Post');
-
-        // Check if node_modules was installed
-        const nextPackageJson = JSON.parse(
-          fs
-            .readFileSync(
-              path.join(
-                ctx.workspace!,
-                'test-dir',
-                'node_modules',
-                'next',
-                'package.json'
-              )
-            )
-            .toString()
-        );
-        expect(nextPackageJson.name).to.equal('next');
+  mockRegistry(test)
+    .stdout()
+    .stderr()
+    .cliActions([
+      `Loading project template "${REPO_PATH}"`,
+      'Installing node dependencies',
+      'Updating dependencies',
+    ])
+    .login()
+    .api(GET_REPOSITORY_URL_QUERY, registryUrlResult)
+    .timeout(180000)
+    .workspaceCommand(EMPTY_DIR, ['init', 'test-dir', REPO_PATH])
+    .it('initializes project successfully from template URL', (ctx) => {
+      // Check slicknode.yml content
+      const slicknodeYml = yaml.safeLoad(
+        fs
+          .readFileSync(path.join(ctx.workspace!, 'test-dir', 'slicknode.yml'))
+          .toString()
+      );
+      expect(slicknodeYml).to.deep.equal({
+        dependencies: {
+          '@private/blog': './modules/blog',
+          auth: 'latest',
+          content: 'latest',
+          core: 'latest',
+          image: 'latest',
+          relay: 'latest',
+        },
       });
 
-    mockRegistry(test)
-      .stdout()
-      .stderr()
-      .cliActions([
-        'Loading project template',
-        'Installing node dependencies',
-        'Updating dependencies',
-      ])
-      .login()
-      .api(GET_REPOSITORY_URL_QUERY, registryUrlResult)
-      .timeout(180000)
-      .workspaceCommand(EMPTY_DIR, [
-        'init',
-        'test-dir',
-        'https://github.com/slicknode/starter-nextjs-blog.git#b3262fc1ac2793e7199ba8b2b546d767c45ad4e2',
-      ])
-      .it('initializes from commit hash successfully', (ctx) => {
-        // Check slicknode.yml content
-        const slicknodeYml = yaml.safeLoad(
-          fs
-            .readFileSync(
-              path.join(ctx.workspace!, 'test-dir', 'slicknode.yml')
+      // Check if core modules were added to cache
+      const coreModuleYml = yaml.safeLoad(
+        fs
+          .readFileSync(
+            path.join(
+              ctx.workspace!,
+              'test-dir',
+              '.slicknode',
+              'cache',
+              'modules',
+              'core',
+              'slicknode.yml'
             )
-            .toString()
-        );
-        expect(slicknodeYml).to.deep.equal({
-          dependencies: {
-            auth: 'latest',
-            core: 'latest',
-            relay: 'latest',
-          },
-        });
-
-        // Check if core modules were added to cache
-        const coreModuleYml = yaml.safeLoad(
-          fs
-            .readFileSync(
-              path.join(
-                ctx.workspace!,
-                'test-dir',
-                '.slicknode',
-                'cache',
-                'modules',
-                'core',
-                'slicknode.yml'
-              )
-            )
-            .toString()
-        );
-        expect(coreModuleYml).to.deep.equal({
-          module: { id: 'core', label: 'Core' },
-        });
-
-        // Check schema.graphql of core module
-        const coreSchema = parse(
-          fs
-            .readFileSync(
-              path.join(
-                ctx.workspace!,
-                'test-dir',
-                '.slicknode',
-                'cache',
-                'modules',
-                'core',
-                'schema.graphql'
-              )
-            )
-            .toString()
-        );
-        expect(coreSchema.kind).to.equal(Kind.DOCUMENT);
-        expect(coreSchema.definitions.length).to.be.above(5);
-
-        expect(ctx.stdout).to.contain('Project initialized');
-
-        // Check if node_modules was installed
-        const packageJson = JSON.parse(
-          fs
-            .readFileSync(path.join(ctx.workspace!, 'test-dir', 'package.json'))
-            .toString()
-        );
-        expect(packageJson.dependencies).to.deep.equal({
-          next: '^9.5.3',
-          react: '^16.13.1',
-          'react-dom': '^16.13.1',
-        });
+          )
+          .toString()
+      );
+      expect(coreModuleYml).to.deep.equal({
+        module: { id: 'core', label: 'Core' },
       });
-  }
+
+      // Check schema.graphql of core module
+      const coreSchema = parse(
+        fs
+          .readFileSync(
+            path.join(
+              ctx.workspace!,
+              'test-dir',
+              '.slicknode',
+              'cache',
+              'modules',
+              'core',
+              'schema.graphql'
+            )
+          )
+          .toString()
+      );
+      expect(coreSchema.kind).to.equal(Kind.DOCUMENT);
+      expect(coreSchema.definitions.length).to.be.above(5);
+
+      expect(ctx.stdout).to.contain('Project initialized');
+
+      // Check if blog module was downloaded from git
+      const blogSchema = parse(
+        fs
+          .readFileSync(
+            path.join(
+              ctx.workspace!,
+              'test-dir',
+              'modules',
+              'blog',
+              'schema.graphql'
+            )
+          )
+          .toString()
+      );
+      expect(blogSchema.kind).to.equal(Kind.DOCUMENT);
+      expect(blogSchema.definitions.length).to.be.above(1);
+
+      const postType: DefinitionNode = blogSchema
+        .definitions[0] as ObjectTypeDefinitionNode;
+      expect(postType.kind).to.equal(Kind.OBJECT_TYPE_DEFINITION);
+      expect(postType.name.value).to.equal('Blog_Post');
+
+      // Check if node_modules was installed
+      const nextPackageJson = JSON.parse(
+        fs
+          .readFileSync(
+            path.join(
+              ctx.workspace!,
+              'test-dir',
+              'node_modules',
+              'next',
+              'package.json'
+            )
+          )
+          .toString()
+      );
+      expect(nextPackageJson.name).to.equal('next');
+    });
+
+  mockRegistry(test)
+    .stdout()
+    .stderr()
+    .cliActions([
+      'Loading project template',
+      'Installing node dependencies',
+      'Updating dependencies',
+    ])
+    .login()
+    .api(GET_REPOSITORY_URL_QUERY, registryUrlResult)
+    .timeout(180000)
+    .workspaceCommand(EMPTY_DIR, [
+      'init',
+      'test-dir',
+      `${REPO_PATH}#b3262fc1ac2793e7199ba8b2b546d767c45ad4e2`,
+    ])
+    .it('initializes from commit hash successfully', (ctx) => {
+      // Check slicknode.yml content
+      const slicknodeYml = yaml.safeLoad(
+        fs
+          .readFileSync(path.join(ctx.workspace!, 'test-dir', 'slicknode.yml'))
+          .toString()
+      );
+      expect(slicknodeYml).to.deep.equal({
+        dependencies: {
+          auth: 'latest',
+          core: 'latest',
+          relay: 'latest',
+        },
+      });
+
+      // Check if core modules were added to cache
+      const coreModuleYml = yaml.safeLoad(
+        fs
+          .readFileSync(
+            path.join(
+              ctx.workspace!,
+              'test-dir',
+              '.slicknode',
+              'cache',
+              'modules',
+              'core',
+              'slicknode.yml'
+            )
+          )
+          .toString()
+      );
+      expect(coreModuleYml).to.deep.equal({
+        module: { id: 'core', label: 'Core' },
+      });
+
+      // Check schema.graphql of core module
+      const coreSchema = parse(
+        fs
+          .readFileSync(
+            path.join(
+              ctx.workspace!,
+              'test-dir',
+              '.slicknode',
+              'cache',
+              'modules',
+              'core',
+              'schema.graphql'
+            )
+          )
+          .toString()
+      );
+      expect(coreSchema.kind).to.equal(Kind.DOCUMENT);
+      expect(coreSchema.definitions.length).to.be.above(5);
+
+      expect(ctx.stdout).to.contain('Project initialized');
+
+      // Check if node_modules was installed
+      const packageJson = JSON.parse(
+        fs
+          .readFileSync(path.join(ctx.workspace!, 'test-dir', 'package.json'))
+          .toString()
+      );
+      expect(packageJson.dependencies).to.deep.equal({
+        next: '^9.5.3',
+        react: '^16.13.1',
+        'react-dom': '^16.13.1',
+      });
+    });
 });
 
 function mockRegistry(t: typeof test) {


### PR DESCRIPTION
This loads the git repo used in the test to test the `slicknode init` command via submodules. 