### PR TITLE
Upgrade S3 storage in CI pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 /oclif.manifest.json
 /.nyc_output
 /coverage
+.env
 
 # We don't need package-lock.json, using yarn
 /package-lock.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       mc mb minio/upload || true &&
       mc mb minio/publicupload || true &&
       mc mb minio/image || true &&
-      mc policy set download minio/publicupload || true &&
-      mc policy set download minio/image || true &&
+      mc anonymous set download minio/publicupload || true &&
+      mc anonymous set download minio/image || true &&
       exit 0
       "
   postgres:

--- a/docs/docs/guides/development-setup.md
+++ b/docs/docs/guides/development-setup.md
@@ -33,7 +33,8 @@ services:
     image: minio/minio
     ports:
       - '9000:9000'
-    command: minio server /export
+      - '9001:9001'
+    command: minio server /export --console-address ":9001"
     environment:
       - MINIO_ACCESS_KEY=fake_access
       - MINIO_SECRET_KEY=fake_secret
@@ -64,8 +65,8 @@ services:
       mc mb minio/upload || true &&
       mc mb minio/publicupload || true &&
       mc mb minio/image || true &&
-      mc policy set download minio/publicupload || true &&
-      mc policy set download minio/image || true &&
+      mc anonymous set download minio/publicupload || true &&
+      mc anonymous set download minio/image || true &&
       exit 0
       "
 ```


### PR DESCRIPTION
The `mc` client API to initialize the storage has changed. Update CI scripts and docs to use the new API for setting public access policies on buckets. 